### PR TITLE
dkms: fix compatible issue with Arch PKGBUILD

### DIFF
--- a/dkms.conf
+++ b/dkms.conf
@@ -1,5 +1,5 @@
-PACKAGE_NAME="i915-sriov"
-PACKAGE_VERSION="6.1"
+PACKAGE_NAME="@_PKGBASE@"
+PACKAGE_VERSION="@PKGVER@"
 
 MAKE[0]="make -j$(nproc) -C ${kernel_source_dir} M=${dkms_tree}/${PACKAGE_NAME}/${PACKAGE_VERSION}/build"
 CLEAN="make -j$(nproc) -C ${kernel_source_dir} M=${dkms_tree}/${PACKAGE_NAME}/${PACKAGE_VERSION}/build clean"


### PR DESCRIPTION
Fix AUR install issue mentioned in https://github.com/strongtz/i915-sriov-dkms/issues/18#issuecomment-1367105944 .