### PR TITLE
Fix LLVM16 ThinLTO/kCFI Build

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -2,7 +2,7 @@
 
 _pkgbase=i915-sriov-dkms
 pkgname=i915-sriov-dkms-git
-pkgver=5.15.71
+pkgver=6.1.11
 pkgrel=1
 pkgdesc="Linux i915 module patched with SR-IOV support"
 arch=('x86_64')

--- a/drivers/gpu/drm/i915/intel_runtime_pm.c
+++ b/drivers/gpu/drm/i915/intel_runtime_pm.c
@@ -71,7 +71,9 @@ track_intel_runtime_pm_wakeref(struct intel_runtime_pm *rpm)
 static void untrack_intel_runtime_pm_wakeref(struct intel_runtime_pm *rpm,
 					     intel_wakeref_t wakeref)
 {
+#if IS_ENABLED(CONFIG_DRM_I915_TRACK_WAKEREF)
 	intel_wakeref_tracker_remove(&rpm->debug, wakeref);
+#endif
 }
 
 static void untrack_all_intel_runtime_pm_wakerefs(struct intel_runtime_pm *rpm)


### PR DESCRIPTION
LLVM16 (still in RC, required for kCFI) complains about the lack of definition for `intel_wakeref_tracker_remove` when making its way through `#if IS_ENABLED(CONFIG_DRM_I915_DEBUG_RUNTIME_PM)` section in `intel_runtime_pm.c`.
Mitigate the concern by gating the call with a check for `CONFIG_DRM_I915_TRACK_WAKEREF` (without which the entire call chain makes no sense anyway).

Update PKGBUILD to 6.1.11