### PR TITLE
6.2 gate for call to intel_pxp_tee_stream_message

### DIFF
--- a/drivers/gpu/drm/i915/pxp/intel_pxp_huc.c
+++ b/drivers/gpu/drm/i915/pxp/intel_pxp_huc.c
@@ -37,7 +37,7 @@ int intel_pxp_huc_load_and_auth(struct intel_pxp *pxp)
 	huc_in.header.status      = 0;
 	huc_in.header.buffer_len  = sizeof(huc_in.huc_base_address);
 	huc_in.huc_base_address   = huc_phys_addr;
-
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(6,2,0))
 	err = intel_pxp_tee_stream_message(pxp, client_id, fence_id,
 					   &huc_in, sizeof(huc_in),
 					   &huc_out, sizeof(huc_out));
@@ -64,6 +64,6 @@ int intel_pxp_huc_load_and_auth(struct intel_pxp *pxp)
 			huc_out.header.status);
 		return -EPROTO;
 	}
-
+#endif
 	return 0;
 }


### PR DESCRIPTION
intel_pxp_tee_stream_message does not exist in 6.1, and compiling with RAP on GCC or with LTO+kCFI on LLVM results in an implicit declaration error (likely other configuraitons too, no clue how vanilla 6.1 users are faring).