### PR TITLE
Fix NULL pointer dereference error in wa_list_apply

### DIFF
--- a/drivers/gpu/drm/i915/gt/intel_workarounds.c
+++ b/drivers/gpu/drm/i915/gt/intel_workarounds.c
@@ -1837,7 +1837,7 @@ static void wa_list_apply(const struct i915_wa_list *wal)
 
 	fw = wal_get_fw_for_rmw(uncore, wal);
 
-	intel_gt_mcr_lock(gt, &flags);
+	spin_lock_irqsave(&uncore->lock, flags);
 	spin_lock(&uncore->lock);
 	intel_uncore_forcewake_get__locked(uncore, fw);
 


### PR DESCRIPTION
Test in linux-6.2.13-200.fc37.x86_64 in Fedora 37, may also fixed the same issue in Ubuntu(#66) and Fedora Host([62](https://github.com/strongtz/i915-sriov-dkms/issues/62#issuecomment-1522107605))