### PR TITLE
CFI-Compatible Shims and Miscellaneous Fixes

### DIFF
--- a/drivers/gpu/drm/i915/gt/gen8_ppgtt.c
+++ b/drivers/gpu/drm/i915/gt/gen8_ppgtt.c
@@ -33,6 +33,12 @@ static u64 gen8_pde_encode(const dma_addr_t addr,
 	return pde;
 }
 
+static u64 gen8_pde_encode_shim(dma_addr_t addr,
+			  unsigned int pat_index)
+{
+	return gen8_pde_encode(addr, (enum i915_cache_level)pat_index);
+}
+
 static u64 gen8_pte_encode(dma_addr_t addr,
 			   enum i915_cache_level level,
 			   u32 flags)
@@ -60,6 +66,13 @@ static u64 gen8_pte_encode(dma_addr_t addr,
 	return pte;
 }
 
+static u64 gen8_pte_encode_shim(dma_addr_t addr,
+			  unsigned int pat_index,
+			  u32 flags)
+{
+	return gen8_pte_encode(addr, (enum i915_cache_level)pat_index, flags);
+}
+
 static u64 gen12_pte_encode(dma_addr_t addr,
 			  unsigned int pat_index,
 			  u32 flags)
@@ -85,6 +98,13 @@ static u64 gen12_pte_encode(dma_addr_t addr,
 		pte |= GEN12_PPGTT_PTE_PAT3;
 
 	return pte;
+}
+
+static u64 gen12_pte_encode_shim(dma_addr_t addr,
+			  enum i915_cache_level level,
+			  u32 flags)
+{
+	return gen12_pte_encode(addr, (unsigned int)level, flags);
 }
 
 static void gen8_ppgtt_notify_vgt(struct i915_ppgtt *ppgtt, bool create)
@@ -1004,7 +1024,7 @@ struct i915_ppgtt *gen8_ppgtt_create(struct intel_gt *gt,
 	if (GRAPHICS_VER(gt->i915) >= 12)
 		ppgtt->vm.pte_encode = gen12_pte_encode;
 	else
-		ppgtt->vm.pte_encode = gen8_pte_encode;
+		ppgtt->vm.pte_encode = gen8_pte_encode_shim;
 
 	ppgtt->vm.bind_async_flags = I915_VMA_LOCAL_BIND;
 	ppgtt->vm.insert_entries = gen8_ppgtt_insert;

--- a/drivers/gpu/drm/i915/gt/intel_ggtt.c
+++ b/drivers/gpu/drm/i915/gt/intel_ggtt.c
@@ -1036,7 +1036,7 @@ static int gen8_gmch_probe(struct i915_ggtt *ggtt)
  * so these PTE encode functions are left with using cache_level.
  * See translation table LEGACY_CACHELEVEL.
  */
-static u64 snb_pte_encode(dma_addr_t addr,
+static u64 _snb_pte_encode(dma_addr_t addr,
 			  enum i915_cache_level level,
 			  u32 flags)
 {
@@ -1057,7 +1057,14 @@ static u64 snb_pte_encode(dma_addr_t addr,
 	return pte;
 }
 
-static u64 ivb_pte_encode(dma_addr_t addr,
+static u64 snb_pte_encode(dma_addr_t addr,
+			   unsigned int level,
+			   u32 flags)
+{
+	return _snb_pte_encode(addr, (enum i915_cache_level)level, flags);
+}
+
+static u64 _ivb_pte_encode(dma_addr_t addr,
 			  enum i915_cache_level level,
 			  u32 flags)
 {
@@ -1080,7 +1087,14 @@ static u64 ivb_pte_encode(dma_addr_t addr,
 	return pte;
 }
 
-static u64 byt_pte_encode(dma_addr_t addr,
+static u64 ivb_pte_encode(dma_addr_t addr,
+			   unsigned int level,
+			   u32 flags)
+{
+	return _ivb_pte_encode(addr, (enum i915_cache_level)level, flags);
+}
+
+static u64 _byt_pte_encode(dma_addr_t addr,
 			  enum i915_cache_level level,
 			  u32 flags)
 {
@@ -1095,7 +1109,14 @@ static u64 byt_pte_encode(dma_addr_t addr,
 	return pte;
 }
 
-static u64 hsw_pte_encode(dma_addr_t addr,
+static u64 byt_pte_encode(dma_addr_t addr,
+			   unsigned int level,
+			   u32 flags)
+{
+	return _byt_pte_encode(addr, (enum i915_cache_level)level, flags);
+}
+
+static u64 _hsw_pte_encode(dma_addr_t addr,
 			  enum i915_cache_level level,
 			  u32 flags)
 {
@@ -1107,7 +1128,14 @@ static u64 hsw_pte_encode(dma_addr_t addr,
 	return pte;
 }
 
-static u64 iris_pte_encode(dma_addr_t addr,
+static u64 hsw_pte_encode(dma_addr_t addr,
+			   unsigned int level,
+			   u32 flags)
+{
+	return _hsw_pte_encode(addr, (enum i915_cache_level)level, flags);
+}
+
+static u64 _iris_pte_encode(dma_addr_t addr,
 			   enum i915_cache_level level,
 			   u32 flags)
 {
@@ -1125,6 +1153,13 @@ static u64 iris_pte_encode(dma_addr_t addr,
 	}
 
 	return pte;
+}
+
+static u64 iris_pte_encode(dma_addr_t addr,
+			   unsigned int level,
+			   u32 flags)
+{
+	return _iris_pte_encode(addr, (enum i915_cache_level)level, flags);
 }
 
 static int gen6_gmch_probe(struct i915_ggtt *ggtt)

--- a/drivers/gpu/drm/i915/gt/intel_ggtt_gmch.c
+++ b/drivers/gpu/drm/i915/gt/intel_ggtt_gmch.c
@@ -18,16 +18,16 @@
 static void gmch_ggtt_insert_page(struct i915_address_space *vm,
 				  dma_addr_t addr,
 				  u64 offset,
-				  enum i915_cache_level cache_level,
+				  unsigned int cache_level,
 				  u32 unused)
 {
-	unsigned int flags = (cache_level == I915_CACHE_NONE) ?
+	unsigned int flags = ((enum i915_cache_level)cache_level == I915_CACHE_NONE) ?
 		AGP_USER_MEMORY : AGP_USER_CACHED_MEMORY;
 
 	intel_gmch_gtt_insert_page(addr, offset >> PAGE_SHIFT, flags);
 }
 
-static void gmch_ggtt_insert_entries(struct i915_address_space *vm,
+static void _gmch_ggtt_insert_entries(struct i915_address_space *vm,
 				     struct i915_vma_resource *vma_res,
 				     enum i915_cache_level cache_level,
 				     u32 unused)
@@ -37,6 +37,14 @@ static void gmch_ggtt_insert_entries(struct i915_address_space *vm,
 
 	intel_gmch_gtt_insert_sg_entries(vma_res->bi.pages, vma_res->start >> PAGE_SHIFT,
 					 flags);
+}
+
+static void gmch_ggtt_insert_entries(struct i915_address_space *vm,
+				     struct i915_vma_resource *vma_res,
+				     unsigned int cache_level,
+				     u32 unused)
+{
+	_gmch_ggtt_insert_entries(vm, vma_res, (enum i915_cache_level)cache_level, unused);
 }
 
 static void gmch_ggtt_invalidate(struct i915_ggtt *ggtt)

--- a/drivers/gpu/drm/i915/gt/intel_gtt.h
+++ b/drivers/gpu/drm/i915/gt/intel_gtt.h
@@ -665,7 +665,7 @@ __set_pd_entry(struct i915_page_directory * const pd,
 	       u64 (*encode)(const dma_addr_t, const unsigned int pat_index));
 
 #define set_pd_entry(pd, idx, to) \
-	__set_pd_entry((pd), (idx), px_pt(to), gen8_pde_encode)
+	__set_pd_entry((pd), (idx), px_pt(to), gen8_pde_encode_shim)
 
 void
 clear_pd_entry(struct i915_page_directory * const pd,

--- a/drivers/gpu/drm/i915/gt/uc/intel_guc_slpc.c
+++ b/drivers/gpu/drm/i915/gt/uc/intel_guc_slpc.c
@@ -10,6 +10,7 @@
 #include "i915_reg.h"
 #include "intel_guc_slpc.h"
 #include "intel_mchbar_regs.h"
+#include "intel_guc_print.h"
 #include "gt/intel_gt.h"
 #include "gt/intel_gt_regs.h"
 #include "gt/intel_rps.h"

--- a/include/linux/ioport.h
+++ b/include/linux/ioport.h
@@ -318,6 +318,8 @@ extern void __devm_release_region(struct device *dev, struct resource *parent,
 				  resource_size_t start, resource_size_t n);
 extern int iomem_map_sanity_check(resource_size_t addr, unsigned long size);
 extern bool iomem_is_exclusive(u64 addr);
+extern bool resource_is_exclusive(struct resource *resource, u64 addr,
+				  resource_size_t size);
 
 extern int
 walk_system_ram_range(unsigned long start_pfn, unsigned long nr_pages,


### PR DESCRIPTION
Grsecurity's RAP does not tolerate inconsistent call signatures resulting from dynamic dispatch used to differentiate the gen11/12 hardware from older equipment. Haven't tested on LLVM's kCFI since the relevant changes were introduced, but good chance that it will not abide these mismatches as well.

Implement explicitly-casting function shims to provide consistent signatures and inform the compiler of the type conversion without attempting to rely on inference/undefined behavior.

Implement several bug-fixes for misc compiler errors encountered during the 6.4 port.