### PR TITLE
Add support for Linux 6.5.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Linux i915 driver with SR-IOV support (dkms module) for linux 6.1 ~ linux 6.4
+# Linux i915 driver with SR-IOV support (dkms module) for linux 6.1 ~ linux 6.5
 
 Originally from [linux-intel-lts](https://github.com/intel/linux-intel-lts/tree/lts-v5.15.49-adl-linux-220826T092047Z/drivers/gpu/drm/i915)
 Update to [6.1.12](https://github.com/intel/linux-intel-lts/tree/lts-v6.1.12-linux-230415T124447Z/drivers/gpu/drm/i915)

--- a/drivers/gpu/drm/i915/display/intel_connector.c
+++ b/drivers/gpu/drm/i915/display/intel_connector.c
@@ -280,14 +280,22 @@ intel_attach_aspect_ratio_property(struct drm_connector *connector)
 void
 intel_attach_hdmi_colorspace_property(struct drm_connector *connector)
 {
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6,5,0)
+	if (!drm_mode_create_hdmi_colorspace_property(connector, 0))
+#else
 	if (!drm_mode_create_hdmi_colorspace_property(connector))
+#endif
 		drm_connector_attach_colorspace_property(connector);
 }
 
 void
 intel_attach_dp_colorspace_property(struct drm_connector *connector)
 {
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6,5,0)
+	if (!drm_mode_create_dp_colorspace_property(connector, 0))
+#else
 	if (!drm_mode_create_dp_colorspace_property(connector))
+#endif
 		drm_connector_attach_colorspace_property(connector);
 }
 

--- a/drivers/gpu/drm/i915/display/intel_display_core.h
+++ b/drivers/gpu/drm/i915/display/intel_display_core.h
@@ -379,7 +379,9 @@ struct intel_display {
 	} gmbus;
 
 	struct {
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(6,4,0)
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6,5,0)
+		struct i915_hdcp_arbiter *master;
+#elif LINUX_VERSION_CODE >= KERNEL_VERSION(6,4,0)
 		struct i915_hdcp_master *master;
 #else
 		struct i915_hdcp_comp_master *master;

--- a/drivers/gpu/drm/i915/display/intel_display_debugfs.c
+++ b/drivers/gpu/drm/i915/display/intel_display_debugfs.c
@@ -534,7 +534,11 @@ static void intel_dp_info(struct seq_file *m,
 static void intel_dp_mst_info(struct seq_file *m,
 			      struct intel_connector *intel_connector)
 {
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6,5,0)
+	bool has_audio = intel_connector->base.display_info.has_audio;
+#else
 	bool has_audio = intel_connector->port->has_audio;
+#endif
 
 	seq_printf(m, "\taudio support: %s\n", str_yes_no(has_audio));
 }

--- a/drivers/gpu/drm/i915/display/intel_dp_mst.c
+++ b/drivers/gpu/drm/i915/display/intel_dp_mst.c
@@ -289,7 +289,11 @@ static int intel_dp_mst_compute_config(struct intel_encoder *encoder,
 	pipe_config->has_pch_encoder = false;
 
 	if (intel_conn_state->force_audio == HDMI_AUDIO_AUTO)
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6,5,0)
+		pipe_config->has_audio = connector->base.display_info.has_audio;
+#else
 		pipe_config->has_audio = connector->port->has_audio;
+#endif
 	else
 		pipe_config->has_audio =
 			intel_conn_state->force_audio == HDMI_AUDIO_ON;

--- a/drivers/gpu/drm/i915/display/intel_hdcp.c
+++ b/drivers/gpu/drm/i915/display/intel_hdcp.c
@@ -1143,7 +1143,9 @@ hdcp2_prepare_ake_init(struct intel_connector *connector,
 	struct intel_digital_port *dig_port = intel_attached_dig_port(connector);
 	struct hdcp_port_data *data = &dig_port->hdcp_port_data;
 	struct drm_i915_private *dev_priv = to_i915(connector->base.dev);
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(6,4,0)
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6,5,0)
+	struct i915_hdcp_arbiter *comp;
+#elif LINUX_VERSION_CODE >= KERNEL_VERSION(6,4,0)
 	struct i915_hdcp_master *comp;
 #else
 	struct i915_hdcp_comp_master *comp;
@@ -1181,7 +1183,9 @@ hdcp2_verify_rx_cert_prepare_km(struct intel_connector *connector,
 	struct intel_digital_port *dig_port = intel_attached_dig_port(connector);
 	struct hdcp_port_data *data = &dig_port->hdcp_port_data;
 	struct drm_i915_private *dev_priv = to_i915(connector->base.dev);
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(6,4,0)
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6,5,0)
+	struct i915_hdcp_arbiter *comp;
+#elif LINUX_VERSION_CODE >= KERNEL_VERSION(6,4,0)
 	struct i915_hdcp_master *comp;
 #else
 	struct i915_hdcp_comp_master *comp;
@@ -1217,7 +1221,9 @@ static int hdcp2_verify_hprime(struct intel_connector *connector,
 	struct intel_digital_port *dig_port = intel_attached_dig_port(connector);
 	struct hdcp_port_data *data = &dig_port->hdcp_port_data;
 	struct drm_i915_private *dev_priv = to_i915(connector->base.dev);
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(6,4,0)
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6,5,0)
+	struct i915_hdcp_arbiter *comp;
+#elif LINUX_VERSION_CODE >= KERNEL_VERSION(6,4,0)
 	struct i915_hdcp_master *comp;
 #else
 	struct i915_hdcp_comp_master *comp;
@@ -1251,7 +1257,9 @@ hdcp2_store_pairing_info(struct intel_connector *connector,
 	struct intel_digital_port *dig_port = intel_attached_dig_port(connector);
 	struct hdcp_port_data *data = &dig_port->hdcp_port_data;
 	struct drm_i915_private *dev_priv = to_i915(connector->base.dev);
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(6,4,0)
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6,5,0)
+	struct i915_hdcp_arbiter *comp;
+#elif LINUX_VERSION_CODE >= KERNEL_VERSION(6,4,0)
 	struct i915_hdcp_master *comp;
 #else
 	struct i915_hdcp_comp_master *comp;
@@ -1286,7 +1294,9 @@ hdcp2_prepare_lc_init(struct intel_connector *connector,
 	struct intel_digital_port *dig_port = intel_attached_dig_port(connector);
 	struct hdcp_port_data *data = &dig_port->hdcp_port_data;
 	struct drm_i915_private *dev_priv = to_i915(connector->base.dev);
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(6,4,0)
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6,5,0)
+	struct i915_hdcp_arbiter *comp;
+#elif LINUX_VERSION_CODE >= KERNEL_VERSION(6,4,0)
 	struct i915_hdcp_master *comp;
 #else
 	struct i915_hdcp_comp_master *comp;
@@ -1321,7 +1331,9 @@ hdcp2_verify_lprime(struct intel_connector *connector,
 	struct intel_digital_port *dig_port = intel_attached_dig_port(connector);
 	struct hdcp_port_data *data = &dig_port->hdcp_port_data;
 	struct drm_i915_private *dev_priv = to_i915(connector->base.dev);
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(6,4,0)
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6,5,0)
+	struct i915_hdcp_arbiter *comp;
+#elif LINUX_VERSION_CODE >= KERNEL_VERSION(6,4,0)
 	struct i915_hdcp_master *comp;
 #else
 	struct i915_hdcp_comp_master *comp;
@@ -1355,7 +1367,9 @@ static int hdcp2_prepare_skey(struct intel_connector *connector,
 	struct intel_digital_port *dig_port = intel_attached_dig_port(connector);
 	struct hdcp_port_data *data = &dig_port->hdcp_port_data;
 	struct drm_i915_private *dev_priv = to_i915(connector->base.dev);
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(6,4,0)
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6,5,0)
+	struct i915_hdcp_arbiter *comp;
+#elif LINUX_VERSION_CODE >= KERNEL_VERSION(6,4,0)
 	struct i915_hdcp_master *comp;
 #else
 	struct i915_hdcp_comp_master *comp;
@@ -1392,7 +1406,9 @@ hdcp2_verify_rep_topology_prepare_ack(struct intel_connector *connector,
 	struct intel_digital_port *dig_port = intel_attached_dig_port(connector);
 	struct hdcp_port_data *data = &dig_port->hdcp_port_data;
 	struct drm_i915_private *dev_priv = to_i915(connector->base.dev);
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(6,4,0)
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6,5,0)
+	struct i915_hdcp_arbiter *comp;
+#elif LINUX_VERSION_CODE >= KERNEL_VERSION(6,4,0)
 	struct i915_hdcp_master *comp;
 #else
 	struct i915_hdcp_comp_master *comp;
@@ -1429,7 +1445,9 @@ hdcp2_verify_mprime(struct intel_connector *connector,
 	struct intel_digital_port *dig_port = intel_attached_dig_port(connector);
 	struct hdcp_port_data *data = &dig_port->hdcp_port_data;
 	struct drm_i915_private *dev_priv = to_i915(connector->base.dev);
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(6,4,0)
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6,5,0)
+	struct i915_hdcp_arbiter *comp;
+#elif LINUX_VERSION_CODE >= KERNEL_VERSION(6,4,0)
 	struct i915_hdcp_master *comp;
 #else
 	struct i915_hdcp_comp_master *comp;
@@ -1461,7 +1479,9 @@ static int hdcp2_authenticate_port(struct intel_connector *connector)
 	struct intel_digital_port *dig_port = intel_attached_dig_port(connector);
 	struct hdcp_port_data *data = &dig_port->hdcp_port_data;
 	struct drm_i915_private *dev_priv = to_i915(connector->base.dev);
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(6,4,0)
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6,5,0)
+	struct i915_hdcp_arbiter *comp;
+#elif LINUX_VERSION_CODE >= KERNEL_VERSION(6,4,0)
 	struct i915_hdcp_master *comp;
 #else
 	struct i915_hdcp_comp_master *comp;
@@ -1493,7 +1513,9 @@ static int hdcp2_close_mei_session(struct intel_connector *connector)
 {
 	struct intel_digital_port *dig_port = intel_attached_dig_port(connector);
 	struct drm_i915_private *dev_priv = to_i915(connector->base.dev);
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(6,4,0)
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6,5,0)
+	struct i915_hdcp_arbiter *comp;
+#elif LINUX_VERSION_CODE >= KERNEL_VERSION(6,4,0)
 	struct i915_hdcp_master *comp;
 #else
 	struct i915_hdcp_comp_master *comp;
@@ -2234,7 +2256,11 @@ static int i915_hdcp_component_bind(struct device *i915_kdev,
 	drm_dbg(&dev_priv->drm, "I915 HDCP comp bind\n");
 	mutex_lock(&dev_priv->display.hdcp.comp_mutex);
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(6,4,0)
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6,5,0)
+	dev_priv->display.hdcp.master = (struct i915_hdcp_arbiter *)data;
+#else
 	dev_priv->display.hdcp.master = (struct i915_hdcp_master *)data;
+#endif
 	dev_priv->display.hdcp.master->hdcp_dev = mei_kdev;
 #else
 	dev_priv->display.hdcp.master = (struct i915_hdcp_comp_master *)data;

--- a/drivers/gpu/drm/i915/gem/i915_gem_mman.h
+++ b/drivers/gpu/drm/i915/gem/i915_gem_mman.h
@@ -9,6 +9,7 @@
 
 #include <linux/mm_types.h>
 #include <linux/types.h>
+#include <linux/version.h>
 
 struct drm_device;
 struct drm_file;
@@ -29,5 +30,7 @@ void i915_gem_object_release_mmap_gtt(struct drm_i915_gem_object *obj);
 
 void i915_gem_object_runtime_pm_release_mmap_offset(struct drm_i915_gem_object *obj);
 void i915_gem_object_release_mmap_offset(struct drm_i915_gem_object *obj);
-
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6,5,0)
+int i915_gem_fb_mmap(struct drm_i915_gem_object *obj, struct vm_area_struct *vma);
+#endif
 #endif

--- a/drivers/gpu/drm/i915/gem/i915_gem_shmem.c
+++ b/drivers/gpu/drm/i915/gem/i915_gem_shmem.c
@@ -18,6 +18,49 @@
 #include "i915_scatterlist.h"
 #include "i915_trace.h"
 
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6,5,0)
+/*
+ * Move folios to appropriate lru and release the batch, decrementing the
+ * ref count of those folios.
+ */
+static void check_release_folio_batch(struct folio_batch *fbatch)
+{
+	check_move_unevictable_folios(fbatch);
+	__folio_batch_release(fbatch);
+	cond_resched();
+}
+
+void shmem_sg_free_table(struct sg_table *st, struct address_space *mapping,
+			 bool dirty, bool backup)
+{
+	struct sgt_iter sgt_iter;
+	struct folio_batch fbatch;
+	struct folio *last = NULL;
+	struct page *page;
+
+	mapping_clear_unevictable(mapping);
+
+	folio_batch_init(&fbatch);
+	for_each_sgt_page(page, sgt_iter, st) {
+		struct folio *folio = page_folio(page);
+
+		if (folio == last)
+			continue;
+		last = folio;
+		if (dirty)
+			folio_mark_dirty(folio);
+		if (backup)
+			folio_mark_accessed(folio);
+
+		if (!folio_batch_add(&fbatch, folio))
+			check_release_folio_batch(&fbatch);
+	}
+	if (fbatch.nr)
+		check_release_folio_batch(&fbatch);
+
+	sg_free_table(st);
+}
+#else
 /*
  * Move pages to appropriate lru and release the pagevec, decrementing the
  * ref count of those pages.
@@ -54,6 +97,7 @@ void shmem_sg_free_table(struct sg_table *st, struct address_space *mapping,
 
 	sg_free_table(st);
 }
+#endif
 
 int shmem_sg_alloc_table(struct drm_i915_private *i915, struct sg_table *st,
 			 size_t size, struct intel_memory_region *mr,


### PR DESCRIPTION
Tested desktop workloads (video QSV decode/encode and 3D accel) on Ubuntu 22.04 host and Windows 11 guest.