### PR TITLE
fixing build for  >= 6.6.14. Adjusting for signature change of drm_dp…

### DIFF
--- a/drivers/gpu/drm/i915/display/intel_dp_mst.c
+++ b/drivers/gpu/drm/i915/display/intel_dp_mst.c
@@ -82,10 +82,15 @@ static int intel_dp_mst_find_vcpi_slots_for_bpp(struct intel_encoder *encoder,
 	}
 
 	for (bpp = max_bpp; bpp >= min_bpp; bpp -= step) {
+	  #if LINUX_VERSION_CODE < KERNEL_VERSION(6,6,14)
 		crtc_state->pbn = drm_dp_calc_pbn_mode(adjusted_mode->crtc_clock,
 						       dsc ? bpp << 4 : bpp,
 						       dsc);
-
+    #endif
+    #if LINUX_VERSION_CODE >= KERNEL_VERSION(6,6,14)
+    		crtc_state->pbn = drm_dp_calc_pbn_mode(adjusted_mode->crtc_clock,
+						       dsc ? bpp << 4 : bpp);
+    #endif
 		drm_dbg_kms(&i915->drm, "Trying bpp %d\n", bpp);
 
 		slots = drm_dp_atomic_find_time_slots(state, &intel_dp->mst_mgr,
@@ -896,9 +901,14 @@ intel_dp_mst_mode_valid_ctx(struct drm_connector *connector,
 	ret = drm_modeset_lock(&mgr->base.lock, ctx);
 	if (ret)
 		return ret;
-
-	if (mode_rate > max_rate || mode->clock > max_dotclk ||
-	    drm_dp_calc_pbn_mode(mode->clock, min_bpp, false) > port->full_pbn) {
+	  #if LINUX_VERSION_CODE < KERNEL_VERSION(6,6,14)
+	    if (mode_rate > max_rate || mode->clock > max_dotclk ||
+	        drm_dp_calc_pbn_mode(mode->clock, min_bpp, false) > port->full_pbn) {
+    #endif
+    #if LINUX_VERSION_CODE >= KERNEL_VERSION(6,6,14)
+	    if (mode_rate > max_rate || mode->clock > max_dotclk ||
+	        drm_dp_calc_pbn_mode(mode->clock, min_bpp) > port->full_pbn) {
+    #endif
 		*status = MODE_CLOCK_HIGH;
 		return 0;
 	}


### PR DESCRIPTION
The signature of 
`drm_dp_calc_pbn_mode(int clock, int bpp, bool dsc)`
has been changed due to the dsc flag being obsolete (so the author of that change in the linux kernel).

I adjusted the affected files in the sourcecode in a similar way as for my previous PR. 

This should fix #135  (or be part of the fix).

For me this still built with 6.6.8. Unfortunately I do not have a system with 6.6.14 avail right now. 