### PR TITLE
Update dkms install command in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ You can create up to 7 VFs on UHD Graphics 770
 2. Install some tools. `apt install build-* dkms`
 3. Go inside the repo, edit the `dkms.conf`file, change the `PACKAGE_NAME` to `i915-sriov-dkms`, and change the `PACKAGE_VERSION` to `6.1`. Save the file.
 4. Move the entire content of the repository to `/usr/src/i915-sriov-dkms-6.1`. The folder name will be the DKMS package name.
-5. Execute command `dkms -i -m i915-sriov-dkms -v 6.1`. `-m` argument denotes the package name, and it should be the same as the folder name which contains the package content. `-v` argument denotes the package version, which we have specified in the `dkms.conf` as `6.1`
+5. Execute command `dkms install -m i915-sriov-dkms -v 6.1 --force`. `-m` argument denotes the package name, and it should be the same as the folder name which contains the package content. `-v` argument denotes the package version, which we have specified in the `dkms.conf` as `6.1`. `--force` argument will reinstall the module even if a module with same name has been already installed.
 6. The kernel module should begin building.
 7. Once finished, we need to make a few changes to the kernel commandline. `nano /etc/default/grub` and change `GRUB_CMDLINE_LINUX_DEFAULT` to 'intel_iommu=on i915.enable_guc=3 i915.max_vfs=7`, or add to it if you have other arguments there already.
 8. Update `grub` and `initrramfs` by executing `update-grub` and `update-initramfs -u`


### PR DESCRIPTION
- Changes the `dkms -i` to `dkms install`
- Add `--force` argument to override the default behavior where the built module will NOT be reinstalled if there is an existing module with same name

Tesed on PVE kernel 6.5.13-3-pve 