### PR TITLE
[DO NOT PR] Firmware Loading Fix for PVE 8.1/6.5.13-5

### DIFF
--- a/drivers/gpu/drm/i915/gt/iov/intel_iov_query.c
+++ b/drivers/gpu/drm/i915/gt/iov/intel_iov_query.c
@@ -103,7 +103,8 @@ static int vf_handshake_with_guc(struct intel_iov *iov)
 		goto fail;
 
 	/* XXX we only support one version, there must be a match */
-	if (major != GUC_VF_VERSION_LATEST_MAJOR || (minor != GUC_VF_VERSION_LATEST_MINOR && minor != GUC_VF_VERSION_ALTERNATE_MINOR))
+        /* This line was changed by PR #126 and the additional checks for the ALTERNATE_MINOR is causing problems in PVE 8.1/6.15-13. I do not know if this will break compatibility with older versions/kernels so use at your own risk. */
+	if (major != GUC_VF_VERSION_LATEST_MAJOR || minor != GUC_VF_VERSION_LATEST_MINOR)
 		goto fail;
 
 	guc_info(iov_to_guc(iov), "interface version %u.%u.%u.%u\n",

--- a/drivers/gpu/drm/i915/gt/uc/abi/guc_version_abi.h
+++ b/drivers/gpu/drm/i915/gt/uc/abi/guc_version_abi.h
@@ -7,7 +7,9 @@
 #define _ABI_GUC_VERSION_ABI_H
 
 #define GUC_VF_VERSION_LATEST_MAJOR	1
-#define GUC_VF_VERSION_LATEST_MINOR	0
-#define GUC_VF_VERSION_ALTERNATE_MINOR	4
+
+/* NOTE: This MINOR version is what can be loaded in PVE8.1/6.15-13. Use at your own risk. */
+#define GUC_VF_VERSION_LATEST_MINOR	9
+
 
 #endif /* _ABI_GUC_VERSION_ABI_H */


### PR DESCRIPTION
…. This will load the 0.1.9.0 firmware for GuC correctly. If only the guc_version_abi.h is changed, the version checks in intel_iov_query.h will prevent the build since it can't find a ALTERNATE_MINOR version. I have not taken a good look at the diffs between PVE8.0/6.2.15 (what I upgraded from) so **I can't say this change won't break compatibility with older versions/kernels**.

This PR will get rid of the error messages shown as follows:
```
[   10.334639] snd_hda_intel 0000:00:1f.3: bound 0000:00:02.0 (ops i915_audio_component_bind_ops [i915])
[   10.334768] i915 0000:00:02.0: 7 VFs could be associated with this PF
[   10.335241] i915 0000:00:02.0: [drm] Cannot find any crtc or sizes
[   10.335892] i915 0000:00:02.0: [drm] Cannot find any crtc or sizes
[   13.132785] i915 0000:00:02.0: vgaarb: changed VGA decodes: olddecodes=io+mem,decodes=none:owns=io+mem
[   13.132842] i915 0000:00:02.1: enabling device (0000 -> 0002)
[   13.132863] i915 0000:00:02.1: Running in SR-IOV VF mode
[   13.133838] i915 0000:00:02.1: [drm] *ERROR* GT0: IOV: Unable to confirm version 1.9 (0000000000000000)
[   13.133853] i915 0000:00:02.1: [drm] *ERROR* GT0: IOV: Found interface version 0.1.9.0
```

 Output after fix:
```
[   10.406880] snd_hda_intel 0000:00:1f.3: bound 0000:00:02.0 (ops i915_audio_component_bind_ops [i915])
[   10.407063] i915 0000:00:02.0: 7 VFs could be associated with this PF
[   10.407519] i915 0000:00:02.0: [drm] Cannot find any crtc or sizes
[   10.408162] i915 0000:00:02.0: [drm] Cannot find any crtc or sizes
[   13.180779] i915 0000:00:02.0: vgaarb: changed VGA decodes: olddecodes=io+mem,decodes=none:owns=io+mem
[   13.180837] i915 0000:00:02.1: enabling device (0000 -> 0002)
[   13.180856] i915 0000:00:02.1: Running in SR-IOV VF mode
[   13.181893] i915 0000:00:02.1: [drm] GT0: GUC: interface version 0.1.9.0
[   13.183065] i915 0000:00:02.1: [drm] VT-d active for gfx access
[   13.183082] i915 0000:00:02.1: [drm] Using Transparent Hugepages
[   13.183431] i915 0000:00:02.1: [drm] GT0: GUC: interface version 0.1.9.0
[   13.183953] i915 0000:00:02.1: GuC firmware PRELOADED version 1.9 submission:SR-IOV VF
[   13.183959] i915 0000:00:02.1: HuC firmware PRELOADED
[   13.185545] i915 0000:00:02.1: [drm] Protected Xe Path (PXP) protected content support initialized
[   13.185548] i915 0000:00:02.1: [drm] PMU not supported for this GPU.
```