### PR TITLE
Fix build for linux-lts (6.6.34)

### DIFF
--- a/drivers/gpu/drm/i915/display/intel_backlight.c
+++ b/drivers/gpu/drm/i915/display/intel_backlight.c
@@ -273,7 +273,7 @@ static void ext_pwm_set_backlight(const struct drm_connector_state *conn_state, 
 	struct intel_panel *panel = &to_intel_connector(conn_state->connector)->panel;
 
 	pwm_set_relative_duty_cycle(&panel->backlight.pwm_state, level, 100);
-	pwm_apply_state(panel->backlight.pwm, &panel->backlight.pwm_state);
+	APPLY_PWM_STATE(panel->backlight.pwm, &panel->backlight.pwm_state);
 }
 
 static void
@@ -439,7 +439,7 @@ static void ext_pwm_disable_backlight(const struct drm_connector_state *old_conn
 	intel_backlight_set_pwm_level(old_conn_state, level);
 
 	panel->backlight.pwm_state.enabled = false;
-	pwm_apply_state(panel->backlight.pwm, &panel->backlight.pwm_state);
+	APPLY_PWM_STATE(panel->backlight.pwm, &panel->backlight.pwm_state);
 }
 
 void intel_backlight_disable(const struct drm_connector_state *old_conn_state)
@@ -759,7 +759,7 @@ static void ext_pwm_enable_backlight(const struct intel_crtc_state *crtc_state,
 
 	pwm_set_relative_duty_cycle(&panel->backlight.pwm_state, level, 100);
 	panel->backlight.pwm_state.enabled = true;
-	pwm_apply_state(panel->backlight.pwm, &panel->backlight.pwm_state);
+	APPLY_PWM_STATE(panel->backlight.pwm, &panel->backlight.pwm_state);
 }
 
 static void __intel_backlight_enable(const struct intel_crtc_state *crtc_state,

--- a/drivers/gpu/drm/i915/display/intel_backlight.h
+++ b/drivers/gpu/drm/i915/display/intel_backlight.h
@@ -7,6 +7,7 @@
 #define __INTEL_BACKLIGHT_H__
 
 #include <linux/types.h>
+#include <linux/version.h>
 
 struct drm_connector_state;
 struct intel_atomic_state;
@@ -35,6 +36,15 @@ void intel_backlight_set_pwm_level(const struct drm_connector_state *conn_state,
 u32 intel_backlight_invert_pwm_level(struct intel_connector *connector, u32 level);
 u32 intel_backlight_level_to_pwm(struct intel_connector *connector, u32 level);
 u32 intel_backlight_level_from_pwm(struct intel_connector *connector, u32 val);
+
+/* it was renamed to pwm_apply_might_sleep from 6.6.33 and 6.8 but not yet in 6.7 */
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 6, 33) || \
+    (LINUX_VERSION_CODE >= KERNEL_VERSION(6, 7, 0) && \
+     LINUX_VERSION_CODE < KERNEL_VERSION(6, 8, 0))
+#define APPLY_PWM_STATE(pwm, pwm_state) pwm_apply_state(pwm, pwm_state)
+#else
+#define APPLY_PWM_STATE(pwm, pwm_state) pwm_apply_might_sleep(pwm, pwm_state)
+#endif
 
 #if IS_ENABLED(CONFIG_BACKLIGHT_CLASS_DEVICE)
 int intel_backlight_device_register(struct intel_connector *connector);


### PR DESCRIPTION
On kernels >v6.6.32 builds fail because `pwm_apply_state()` got renamed to `pwm_apply_might_sleep()` in
`linux/pwm.h`. This does not (yet?) apply to v6.7 but it is the case in v6.8 and onwards.

This creates a macro for the correct function depending on the version and currently builds on linux-lts again.