### PR TITLE
Fix "too few arguments to function 'drm_buddy_free_list'" error on Linux 6.10.x

### DIFF
--- a/drivers/gpu/drm/i915/i915_ttm_buddy_manager.c
+++ b/drivers/gpu/drm/i915/i915_ttm_buddy_manager.c
@@ -179,7 +179,7 @@ static int i915_ttm_buddy_man_alloc(struct ttm_resource_manager *man,
 	return 0;
 
 err_free_blocks:
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(6,11,0)
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6,10,0)
 	drm_buddy_free_list(mm, &bman_res->blocks,0);
 #else
 	drm_buddy_free_list(mm, &bman_res->blocks);
@@ -198,7 +198,7 @@ static void i915_ttm_buddy_man_free(struct ttm_resource_manager *man,
 	struct i915_ttm_buddy_manager *bman = to_buddy_manager(man);
 
 	mutex_lock(&bman->lock);
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(6,11,0)
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6,10,0)
 	drm_buddy_free_list(&bman->mm, &bman_res->blocks, 0);
 #else
 	drm_buddy_free_list(&bman->mm, &bman_res->blocks);
@@ -410,7 +410,7 @@ int i915_ttm_buddy_man_fini(struct ttm_device *bdev, unsigned int type)
 	ttm_set_driver_manager(bdev, type, NULL);
 
 	mutex_lock(&bman->lock);
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(6,11,0)
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6,10,0)
 	drm_buddy_free_list(mm, &bman->reserved, 0);
 #else
 	drm_buddy_free_list(mm, &bman->reserved);


### PR DESCRIPTION
This fix has successfully built and created VFs in the following environments:

OS: Arch Linux
Linux Kernel: 6.10.10-arch1-1
CPU: Intel(R) N100

![image](https://github.com/user-attachments/assets/e9d50c28-6f8b-404a-aed8-308dc5300968)
