### PR TITLE
Updated README.md to reflect new Linux Guest installations (Ubuntu 24.04 LTS/Kernel 6.8)

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ You also can download the package from the [releases page](https://github.com/st
 We will need to run the same driver under Linux guests. 
 1. Install build tools
    ```
-   apt install build-* dkms linux-header-$(uname -r) linux-modules-extra-$(uname -r)
+   apt install build-* dkms linux-headers-$(uname -r) linux-modules-extra-$(uname -r)
    ```
 2. Download and install the `.deb`
    ```


### PR DESCRIPTION
Updated various sections of README.md, verified the steps myself with a clean install of PVE 8.3/Kernel 6.8 and Ubuntu 24.04.1 LTS Guest VM.