### PR TITLE
Arch Linux package: include necessary modprobe configuration

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -12,9 +12,10 @@ depends=('dkms')
 conflicts=("${pkgname}-git")
 backup=("etc/tmpfiles.d/i915-set-sriov-numvfs.conf")
 install=${pkgname}.install
-source=("git+https://github.com/strongtz/i915-sriov-dkms.git" "i915-set-sriov-numvfs.conf")
+source=("git+https://github.com/strongtz/i915-sriov-dkms.git" "i915-set-sriov-numvfs.conf" "i915-modprobe.conf")
 sha256sums=('SKIP'
-            'e85e4d4c97cb1f6e825c47ea5e3a9c18f10761714307985f67b58c8e55a1e2c2')
+            'e85e4d4c97cb1f6e825c47ea5e3a9c18f10761714307985f67b58c8e55a1e2c2'
+            '6660e8f2eeff8712ecf8ad0366d9316e2c8e070d8d81c0f996a3899bb5819a48')
 
 package() {
   cd "$srcdir/$pkgname"
@@ -25,4 +26,5 @@ package() {
 
   cd "$srcdir"
   install -Dm644 i915-set-sriov-numvfs.conf "${pkgdir}/etc/tmpfiles.d/i915-set-sriov-numvfs.conf"
+  install -Dm644 i915-modprobe.conf "${pkgdir}/usr/lib/modprobe.d/i915-sriov-dkms.conf"
 }

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -10,12 +10,12 @@ license=('GPL-2.0-only')
 makedepends=('git')
 depends=('dkms')
 conflicts=("${pkgname}-git")
-backup=("etc/tmpfiles.d/i915-set-sriov-numvfs.conf")
+backup=("etc/tmpfiles.d/i915-set-sriov-numvfs.conf" "etc/modprobe.d/i915-sriov-dkms.conf")
 install=${pkgname}.install
 source=("git+https://github.com/strongtz/i915-sriov-dkms.git" "i915-set-sriov-numvfs.conf" "i915-modprobe.conf")
 sha256sums=('SKIP'
             'e85e4d4c97cb1f6e825c47ea5e3a9c18f10761714307985f67b58c8e55a1e2c2'
-            '3141f71d0c7212e599ce5d3741f38be26f5b41f534975ac6c3062495b26c6192')
+            '5118bf5cb5b0d903c2eaebfd09882c2cf6268735797d4e5d2bfcda67517467eb')
 
 package() {
   cd "$srcdir/$pkgname"

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -15,7 +15,7 @@ install=${pkgname}.install
 source=("git+https://github.com/strongtz/i915-sriov-dkms.git" "i915-set-sriov-numvfs.conf" "i915-modprobe.conf")
 sha256sums=('SKIP'
             'e85e4d4c97cb1f6e825c47ea5e3a9c18f10761714307985f67b58c8e55a1e2c2'
-            '6660e8f2eeff8712ecf8ad0366d9316e2c8e070d8d81c0f996a3899bb5819a48')
+            '3141f71d0c7212e599ce5d3741f38be26f5b41f534975ac6c3062495b26c6192')
 
 package() {
   cd "$srcdir/$pkgname"
@@ -26,5 +26,5 @@ package() {
 
   cd "$srcdir"
   install -Dm644 i915-set-sriov-numvfs.conf "${pkgdir}/etc/tmpfiles.d/i915-set-sriov-numvfs.conf"
-  install -Dm644 i915-modprobe.conf "${pkgdir}/usr/lib/modprobe.d/i915-sriov-dkms.conf"
+  install -Dm644 i915-modprobe.conf "${pkgdir}/etc/modprobe.d/i915-sriov-dkms.conf"
 }

--- a/README.md
+++ b/README.md
@@ -16,6 +16,14 @@ Tested kernel versions: 6.12.10-zen1/6.11.9-arch1/6.10.9-arch1/6.9.10-arch1/6.8.
 intel_iommu=on i915.enable_guc=3 i915.max_vfs=7 module_blacklist=xe
 ```
 
+Besides `intel_iommu=on`, the other 3 parameters could be applied by `modprobe` by putting following content to `/etc/modprobe.d/i915-sriov-dkms.conf`
+
+```
+blacklist xe
+options i915 enable_guc=3
+options i915 max_vfs=7
+```
+
 ## Creating Virtual Functions (VF)
 
 ```

--- a/i915-modprobe.conf
+++ b/i915-modprobe.conf
@@ -1,0 +1,3 @@
+blacklist xe
+options i915 enable_guc=3
+options i915 max_vfs=7

--- a/i915-modprobe.conf
+++ b/i915-modprobe.conf
@@ -1,3 +1,4 @@
+# Uncomment the 3 lines below to set parameters for i915 and avoid xe being loaded.
 #blacklist xe
 #options i915 enable_guc=3
 #options i915 max_vfs=7

--- a/i915-modprobe.conf
+++ b/i915-modprobe.conf
@@ -1,3 +1,3 @@
-blacklist xe
-options i915 enable_guc=3
-options i915 max_vfs=7
+#blacklist xe
+#options i915 enable_guc=3
+#options i915 max_vfs=7

--- a/i915-sriov-dkms.install
+++ b/i915-sriov-dkms.install
@@ -1,6 +1,7 @@
 post_install() {
   echo "The i915 kernel module will be available on reboot."
   echo "You can edit /etc/tmpfiles.d/i915-set-sriov-numvfs.conf to set the number of VFs on boot."
+  echo "You can edit /etc/modprobe.d/i915-sriov-dkms.conf to set parameters for i915 and blocklisting xe."
   echo "Please refer to https://github.com/strongtz/i915-sriov-dkms/blob/master/README.md to set kernel parameters."
 }
 


### PR DESCRIPTION
The kernel command line in `README.md`

```
i915.enable_guc=3 i915.max_vfs=7 module_blacklist=xe
```

could be translated into a `modprobe` configuration file:

```
blacklist xe
options i915 enable_guc=3
options i915 max_vfs=7
```

This patch creates such file and including it with Arch Linux `PKGBUILD`.