### PR TITLE
Use absolute paths for including the trace header

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,8 @@ LINUXINCLUDE := \
 
 subdir-ccflags-y += \
 	-DDKMS_MODULE_VERSION='$(DKMS_MODULE_VERSION)' \
-	-DDKMS_MODULE_ORIGIN_KERNEL='$(DKMS_MODULE_ORIGIN_KERNEL)'
+	-DDKMS_MODULE_ORIGIN_KERNEL='$(DKMS_MODULE_ORIGIN_KERNEL)' \
+	-DDKMS_MODULE_SOURCE_DIR='$(abspath $(src))'
 
 obj-m += compat/
 obj-m += drivers/gpu/drm/i915/

--- a/drivers/gpu/drm/i915/display/intel_display_trace.h
+++ b/drivers/gpu/drm/i915/display/intel_display_trace.h
@@ -853,6 +853,6 @@ TRACE_EVENT(intel_frontbuffer_flush,
 /* This part must be outside protection */
 #undef TRACE_INCLUDE_PATH
 #undef TRACE_INCLUDE_FILE
-#define TRACE_INCLUDE_PATH ../../drivers/gpu/drm/i915/display
+#define TRACE_INCLUDE_PATH MODULE_ABS_PATH(drivers/gpu/drm/i915/display)
 #define TRACE_INCLUDE_FILE intel_display_trace
 #include <trace/define_trace.h>

--- a/drivers/gpu/drm/i915/gvt/trace.h
+++ b/drivers/gpu/drm/i915/gvt/trace.h
@@ -378,6 +378,6 @@ TRACE_EVENT(render_mmio,
 /* This part must be out of protection */
 #undef TRACE_INCLUDE_PATH
 #undef TRACE_INCLUDE_FILE
-#define TRACE_INCLUDE_PATH ../../drivers/gpu/drm/i915/gvt
+#define TRACE_INCLUDE_PATH MODULE_ABS_PATH(drivers/gpu/drm/i915/gvt)
 #define TRACE_INCLUDE_FILE trace
 #include <trace/define_trace.h>

--- a/drivers/gpu/drm/i915/i915_trace.h
+++ b/drivers/gpu/drm/i915/i915_trace.h
@@ -721,6 +721,6 @@ DEFINE_EVENT(i915_context, i915_context_free,
 /* This part must be outside protection */
 #undef TRACE_INCLUDE_PATH
 #undef TRACE_INCLUDE_FILE
-#define TRACE_INCLUDE_PATH ../../drivers/gpu/drm/i915
+#define TRACE_INCLUDE_PATH MODULE_ABS_PATH(drivers/gpu/drm/i915)
 #define TRACE_INCLUDE_FILE i915_trace
 #include <trace/define_trace.h>

--- a/drivers/gpu/drm/i915/intel_uncore_trace.h
+++ b/drivers/gpu/drm/i915/intel_uncore_trace.h
@@ -44,6 +44,6 @@ TRACE_EVENT_CONDITION(i915_reg_rw,
 /* This part must be outside protection */
 #undef TRACE_INCLUDE_PATH
 #undef TRACE_INCLUDE_FILE
-#define TRACE_INCLUDE_PATH ../../drivers/gpu/drm/i915
+#define TRACE_INCLUDE_PATH MODULE_ABS_PATH(drivers/gpu/drm/i915)
 #define TRACE_INCLUDE_FILE intel_uncore_trace
 #include <trace/define_trace.h>

--- a/drivers/gpu/drm/xe/xe_trace.h
+++ b/drivers/gpu/drm/xe/xe_trace.h
@@ -462,6 +462,6 @@ TRACE_EVENT(xe_eu_stall_data_read,
 /* This part must be outside protection */
 #undef TRACE_INCLUDE_PATH
 #undef TRACE_INCLUDE_FILE
-#define TRACE_INCLUDE_PATH ../../drivers/gpu/drm/xe
+#define TRACE_INCLUDE_PATH MODULE_ABS_PATH(drivers/gpu/drm/xe)
 #define TRACE_INCLUDE_FILE xe_trace
 #include <trace/define_trace.h>

--- a/drivers/gpu/drm/xe/xe_trace_bo.h
+++ b/drivers/gpu/drm/xe/xe_trace_bo.h
@@ -258,6 +258,6 @@ DEFINE_EVENT(xe_vm, xe_vm_ops_fail,
 /* This part must be outside protection */
 #undef TRACE_INCLUDE_PATH
 #undef TRACE_INCLUDE_FILE
-#define TRACE_INCLUDE_PATH ../../drivers/gpu/drm/xe
+#define TRACE_INCLUDE_PATH MODULE_ABS_PATH(drivers/gpu/drm/xe)
 #define TRACE_INCLUDE_FILE xe_trace_bo
 #include <trace/define_trace.h>

--- a/drivers/gpu/drm/xe/xe_trace_guc.h
+++ b/drivers/gpu/drm/xe/xe_trace_guc.h
@@ -154,6 +154,6 @@ TRACE_EVENT(xe_guc_engine_activity,
 /* This part must be outside protection */
 #undef TRACE_INCLUDE_PATH
 #undef TRACE_INCLUDE_FILE
-#define TRACE_INCLUDE_PATH ../../drivers/gpu/drm/xe
+#define TRACE_INCLUDE_PATH MODULE_ABS_PATH(drivers/gpu/drm/xe)
 #define TRACE_INCLUDE_FILE xe_trace_guc
 #include <trace/define_trace.h>

--- a/drivers/gpu/drm/xe/xe_trace_lrc.h
+++ b/drivers/gpu/drm/xe/xe_trace_lrc.h
@@ -47,6 +47,6 @@ TRACE_EVENT(xe_lrc_update_timestamp,
 /* This part must be outside protection */
 #undef TRACE_INCLUDE_PATH
 #undef TRACE_INCLUDE_FILE
-#define TRACE_INCLUDE_PATH ../../drivers/gpu/drm/xe
+#define TRACE_INCLUDE_PATH MODULE_ABS_PATH(drivers/gpu/drm/xe)
 #define TRACE_INCLUDE_FILE xe_trace_lrc
 #include <trace/define_trace.h>

--- a/include/config.h
+++ b/include/config.h
@@ -2,6 +2,8 @@
 
 #include "backport.h"
 
+#define MODULE_ABS_PATH(path) DKMS_MODULE_SOURCE_DIR/path
+
 #ifdef CONFIG_DRM_XE_PAGEMAP
 #undef CONFIG_DRM_XE_PAGEMAP
 #endif


### PR DESCRIPTION
Fixed #368 