### PR TITLE
fix load priority issue by moving modules to updates directory

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -48,9 +48,9 @@
 
           installPhase = ''
             install -D drivers/gpu/drm/i915/i915.ko \
-              $out/lib/modules/${kernel.modDirVersion}/kernel/drivers/gpu/drm/i915/i915.ko
+              $out/lib/modules/${kernel.modDirVersion}/updates/drivers/gpu/drm/i915/i915.ko
             install -D compat/intel_sriov_compat.ko \
-              $out/lib/modules/${kernel.modDirVersion}/kernel/compat/gpu/drm/i915/intel_sriov_compat.ko
+              $out/lib/modules/${kernel.modDirVersion}/updates/compat/gpu/drm/i915/intel_sriov_compat.ko
           '';
 
           meta = {
@@ -92,9 +92,9 @@
 
           installPhase = ''
             install -D drivers/gpu/drm/xe/xe.ko \
-              $out/lib/modules/${kernel.modDirVersion}/kernel/drivers/gpu/drm/xe/xe.ko
+              $out/lib/modules/${kernel.modDirVersion}/updates/drivers/gpu/drm/xe/xe.ko
             install -D compat/intel_sriov_compat.ko \
-              $out/lib/modules/${kernel.modDirVersion}/kernel/compat/gpu/drm/xe/intel_sriov_compat.ko
+              $out/lib/modules/${kernel.modDirVersion}/updates/compat/gpu/drm/xe/intel_sriov_compat.ko
           '';
 
           meta = {


### PR DESCRIPTION
Hi, I've been using this module successfully in NixOS for a while, but I'm not sure why it recently stopped loading the patched module on my arrow lake system.

```bash
❯ eza -l /run/booted-system/kernel-modules/lib/modules/$(uname -r)/kernel/drivers/gpu/drm/i915/
lrwxrwxrwx - root 31 Dec  1969 i915.ko -> /nix/store/vh968q3zbbndmykiqcxcd24hr643lav7-i915-sriov-module-2025.12.10-6.18.2/lib/modules/6.18.2/kernel/drivers/gpu/drm/i915/i915.ko
lrwxrwxrwx - root 31 Dec  1969 i915.ko.xz -> /nix/store/zwfzafyd8xg7cj8q5j75n3d8nrkda1j2-linux-6.18.2-modules/lib/modules/6.18.2/kernel/drivers/gpu/drm/i915/i915.ko.xz
```

```bash
❯ modinfo i915 | grep filename
filename:       /run/booted-system/kernel-modules/lib/modules/6.18.2/kernel/drivers/gpu/drm/i915/i915.ko.xz
```

The issue appears to be that even though the SR-IOV patched module is built successfully and present at `i915.ko`, `depmod` is choosing to load the stock unpatched `i915.ko.xz` instead as you can see above. Since both files exist in the same directory `kernel/drivers/...`, depmod behavior is ambiguous and seems to default to the compressed module provided by the upstream kernel.

I tried reverting both this i915 flake and my Linux kernel to previous versions that worked before, but the issue persisted.

This PR fixes this issue by modifying the `installPhase` in `flake.nix` to install the modules into `updates/` instead of `kernel/`. The `updates/` directory is prioritized by `depmod` by default, which fixes this on my machine.

Is anyone else able to test and reproduce this on NixOS? Thanks.