### PR TITLE
Fix build failure in kernel version 6.18.24+ and 6.19.14+

### DIFF
--- a/drivers/gpu/drm/i915/i915_gem.c
+++ b/drivers/gpu/drm/i915/i915_gem.c
@@ -520,8 +520,13 @@ ggtt_write(struct io_mapping *mapping,
 
 	/* We can use the cpu mem copy function because this is X86. */
 	vaddr = io_mapping_map_atomic_wc(mapping, base);
+#ifdef ARCH_HAS_NONTEMPORAL_UACCESS
+	unwritten = copy_from_user_inatomic_nontemporal((void __force *)vaddr + offset,
+						      user_data, length);
+#else
 	unwritten = __copy_from_user_inatomic_nocache((void __force *)vaddr + offset,
 						      user_data, length);
+#endif
 	io_mapping_unmap_atomic(vaddr);
 	if (unwritten) {
 		vaddr = io_mapping_map_wc(mapping, base, PAGE_SIZE);


### PR DESCRIPTION
`__copy_from_user_inatomic_nocache` was renamed to `copy_from_user_inatomic_nontemporal` in <https://github.com/torvalds/linux/commit/5de7bcaadf160c1716b20a263cf8f5b06f658959>. This change was also backported to 6.12 (v6.12.83+), 6.18 (v6.18.24+) and 6.19 (v6.19.14+).

Use the macro that was renamed in the same kernel commit to detect version compatibility

Fixes #442 and #437 
