### PR TITLE
Support Linux kernel 7.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,10 @@
 .vscode/
 src/
 pkg/
+
+# Persönliches Claude-Tooling / Dev-Artefakte (nicht Teil des Upstream-Forks)
+CLAUDE.md
+.claude/
+HANDOFF.md
+build.log
+build-against-kernel.sh

--- a/compat/v7.0/dmabuf_dma_fence.c
+++ b/compat/v7.0/dmabuf_dma_fence.c
@@ -47,9 +47,9 @@ bool dma_fence_check_and_signal(struct dma_fence *fence)
 	unsigned long flags;
 	bool ret;
 
-	spin_lock_irqsave(fence->lock, flags);
+	spin_lock_irqsave(dma_fence_spinlock(fence), flags);
 	ret = dma_fence_check_and_signal_locked(fence);
-	spin_unlock_irqrestore(fence->lock, flags);
+	spin_unlock_irqrestore(dma_fence_spinlock(fence), flags);
 
 	return ret;
 }

--- a/dkms.conf
+++ b/dkms.conf
@@ -20,4 +20,4 @@ DEST_MODULE_LOCATION[3]=/updates
 MAKE[0]="make -C ${kernel_source_dir} M=${dkms_tree}/${PACKAGE_NAME}/${PACKAGE_VERSION}/build"
 
 AUTOINSTALL=yes
-BUILD_EXCLUSIVE_KERNEL="^(6\.1[7-9]|7\.0)"
+BUILD_EXCLUSIVE_KERNEL="^(6\.1[7-9]|7\.[01])"

--- a/drivers/gpu/drm/i915/gt/intel_breadcrumbs.c
+++ b/drivers/gpu/drm/i915/gt/intel_breadcrumbs.c
@@ -148,7 +148,7 @@ __dma_fence_signal__notify(struct dma_fence *fence,
 {
 	struct dma_fence_cb *cur, *tmp;
 
-	lockdep_assert_held(fence->lock);
+	lockdep_assert_held(dma_fence_spinlock(fence));
 
 	list_for_each_entry_safe(cur, tmp, list, node) {
 		INIT_LIST_HEAD(&cur->node);

--- a/drivers/gpu/drm/i915/i915_active.c
+++ b/drivers/gpu/drm/i915/i915_active.c
@@ -1045,9 +1045,9 @@ __i915_active_fence_set(struct i915_active_fence *active,
 	 * nesting rules for the fence->lock; the inner lock is always the
 	 * older lock.
 	 */
-	spin_lock_irqsave(fence->lock, flags);
+	spin_lock_irqsave(dma_fence_spinlock(fence), flags);
 	if (prev)
-		spin_lock_nested(prev->lock, SINGLE_DEPTH_NESTING);
+		spin_lock_nested(dma_fence_spinlock(prev), SINGLE_DEPTH_NESTING);
 
 	/*
 	 * A does the cmpxchg first, and so it sees C or NULL, as before, or
@@ -1061,17 +1061,17 @@ __i915_active_fence_set(struct i915_active_fence *active,
 	 */
 	while (cmpxchg(__active_fence_slot(active), prev, fence) != prev) {
 		if (prev) {
-			spin_unlock(prev->lock);
+			spin_unlock(dma_fence_spinlock(prev));
 			dma_fence_put(prev);
 		}
-		spin_unlock_irqrestore(fence->lock, flags);
+		spin_unlock_irqrestore(dma_fence_spinlock(fence), flags);
 
 		prev = i915_active_fence_get(active);
 		GEM_BUG_ON(prev == fence);
 
-		spin_lock_irqsave(fence->lock, flags);
+		spin_lock_irqsave(dma_fence_spinlock(fence), flags);
 		if (prev)
-			spin_lock_nested(prev->lock, SINGLE_DEPTH_NESTING);
+			spin_lock_nested(dma_fence_spinlock(prev), SINGLE_DEPTH_NESTING);
 	}
 
 	/*
@@ -1088,10 +1088,10 @@ __i915_active_fence_set(struct i915_active_fence *active,
 	 */
 	if (prev) {
 		__list_del_entry(&active->cb.node);
-		spin_unlock(prev->lock); /* serialise with prev->cb_list */
+		spin_unlock(dma_fence_spinlock(prev)); /* serialise with prev->cb_list */
 	}
 	list_add_tail(&active->cb.node, &fence->cb_list);
-	spin_unlock_irqrestore(fence->lock, flags);
+	spin_unlock_irqrestore(dma_fence_spinlock(fence), flags);
 
 	return prev;
 }

--- a/drivers/gpu/drm/xe/xe_dma_buf.c
+++ b/drivers/gpu/drm/xe/xe_dma_buf.c
@@ -286,7 +286,16 @@ static void xe_dma_buf_move_notify(struct dma_buf_attachment *attach)
 
 static const struct dma_buf_attach_ops xe_dma_buf_attach_ops = {
 	.allow_peer2peer = true,
+	/*
+	 * Linux 7.1: dma_buf_attach_ops.move_notify was renamed to
+	 * .invalidate_mappings (same callback signature). Version-gated locally
+	 * instead of a global #define because move_notify is a common name.
+	 */
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(7, 1, 0)
+	.invalidate_mappings = xe_dma_buf_move_notify
+#else
 	.move_notify = xe_dma_buf_move_notify
+#endif
 };
 
 #if IS_ENABLED(CONFIG_DRM_XE_KUNIT_TEST)

--- a/drivers/gpu/drm/xe/xe_hw_fence.c
+++ b/drivers/gpu/drm/xe/xe_hw_fence.c
@@ -124,7 +124,7 @@ static struct xe_hw_fence *to_xe_hw_fence(struct dma_fence *fence);
 
 static struct xe_hw_fence_irq *xe_hw_fence_irq(struct xe_hw_fence *fence)
 {
-	return container_of(fence->dma.lock, struct xe_hw_fence_irq, lock);
+	return container_of(dma_fence_spinlock(&fence->dma), struct xe_hw_fence_irq, lock);
 }
 
 static const char *xe_hw_fence_get_driver_name(struct dma_fence *dma_fence)

--- a/drivers/gpu/drm/xe/xe_sched_job.c
+++ b/drivers/gpu/drm/xe/xe_sched_job.c
@@ -190,11 +190,11 @@ static bool xe_fence_set_error(struct dma_fence *fence, int error)
 	unsigned long irq_flags;
 	bool signaled;
 
-	spin_lock_irqsave(fence->lock, irq_flags);
+	spin_lock_irqsave(dma_fence_spinlock(fence), irq_flags);
 	signaled = test_bit(DMA_FENCE_FLAG_SIGNALED_BIT, &fence->flags);
 	if (!signaled)
 		dma_fence_set_error(fence, error);
-	spin_unlock_irqrestore(fence->lock, irq_flags);
+	spin_unlock_irqrestore(dma_fence_spinlock(fence), irq_flags);
 
 	return signaled;
 }

--- a/drivers/gpu/drm/xe/xe_vsec.c
+++ b/drivers/gpu/drm/xe/xe_vsec.c
@@ -173,8 +173,27 @@ int xe_pmt_telem_read(struct pci_dev *pdev, u32 guid, u64 *data, loff_t user_off
 	return count;
 }
 
+/*
+ * Linux 7.1: struct pmt_callbacks.read_telem and intel_vsec_register() now take
+ * struct device * instead of struct pci_dev *. xe_pmt_telem_read keeps its
+ * pci_dev * signature (internal callers in xe_hwmon.c/xe_debugfs.c and the
+ * prototype in xe_vsec.h stay unchanged); only the callback is bridged through
+ * a thin 7.1 adapter.
+ */
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(7, 1, 0)
+static int xe_pmt_telem_read_cb(struct device *dev, u32 guid, u64 *data,
+				loff_t user_offset, u32 count)
+{
+	return xe_pmt_telem_read(to_pci_dev(dev), guid, data, user_offset, count);
+}
+#endif
+
 static struct pmt_callbacks xe_pmt_cb = {
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(7, 1, 0)
+	.read_telem = xe_pmt_telem_read_cb,
+#else
 	.read_telem = xe_pmt_telem_read,
+#endif
 };
 
 static const int vsec_platforms[] = {
@@ -221,6 +240,10 @@ void xe_vsec_init(struct xe_device *xe)
 	 * Register a VSEC. Cleanup is handled using device managed
 	 * resources.
 	 */
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(7, 1, 0)
+	intel_vsec_register(&pdev->dev, info);
+#else
 	intel_vsec_register(pdev, info);
+#endif
 }
 MODULE_IMPORT_NS("INTEL_VSEC");

--- a/include/config.h
+++ b/include/config.h
@@ -6,6 +6,61 @@
 
 #define MODULE_ABS_PATH(path) DKMS_MODULE_SOURCE_DIR/path
 
+/*
+ * Linux 7.1: the buddy allocator was split out of the DRM subsystem and moved
+ * to <linux/gpu_buddy.h> as gpu_buddy_*. Only the two DRM print helpers
+ * (drm_buddy_print, drm_buddy_block_print) keep their names in
+ * <drm/drm_buddy.h>. The i915 tree vendored from 7.0 only knows the old
+ * drm_buddy_* names — remapped globally here so that struct FIELDS
+ * (struct drm_buddy *mm;) in early-included i915 headers are covered too, not
+ * just the later use sites. That is why this lives in the -include config and
+ * not in a header shim (include-ordering trap).
+ * Macro replacement is token-based: drm_buddy_print stays untouched.
+ */
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(7, 1, 0)
+#define drm_buddy                       gpu_buddy
+#define drm_buddy_block                 gpu_buddy_block
+#define drm_buddy_block_size            gpu_buddy_block_size
+#define drm_buddy_block_offset          gpu_buddy_block_offset
+#define drm_buddy_block_order           gpu_buddy_block_order
+#define drm_buddy_block_is_free         gpu_buddy_block_is_free
+#define drm_buddy_block_is_clear        gpu_buddy_block_is_clear
+#define drm_buddy_block_trim            gpu_buddy_block_trim
+#define drm_buddy_free_block            gpu_buddy_free_block
+#define drm_buddy_free_list             gpu_buddy_free_list
+#define drm_buddy_alloc_blocks          gpu_buddy_alloc_blocks
+#define drm_buddy_init                  gpu_buddy_init
+#define drm_buddy_fini                  gpu_buddy_fini
+#define DRM_BUDDY_RANGE_ALLOCATION      GPU_BUDDY_RANGE_ALLOCATION
+#define DRM_BUDDY_TOPDOWN_ALLOCATION    GPU_BUDDY_TOPDOWN_ALLOCATION
+#define DRM_BUDDY_CONTIGUOUS_ALLOCATION GPU_BUDDY_CONTIGUOUS_ALLOCATION
+#define DRM_BUDDY_CLEAR_ALLOCATION      GPU_BUDDY_CLEAR_ALLOCATION
+#define DRM_BUDDY_CLEARED               GPU_BUDDY_CLEARED
+#endif
+
+/*
+ * Linux 7.1: INTEL_GMCH_CTRL (PCI config offset 0x52 of the GMCH control
+ * register) was renamed to I830_GMCH_CTRL in <drm/intel/i915_drm.h> — same
+ * value (0x52). INTEL_GMCH_VGA_DISABLE is unchanged. Pure rename with identical
+ * semantics -> global #define (class 2), keeping the intel_vga.c vendored from
+ * 7.0 unchanged. Token-based: I830_GMCH_CTRL/SNB_GMCH_CTRL stay untouched.
+ */
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(7, 1, 0)
+#define INTEL_GMCH_CTRL I830_GMCH_CTRL
+#endif
+
+/*
+ * Linux 7.1 ("dynamic dma-buf" rework): the exported function
+ * dma_buf_move_notify(struct dma_buf *) was renamed to
+ * dma_buf_invalidate_mappings() (same signature/semantics: notify importers of
+ * a move). Unique token -> global #define (class 2). The corresponding callback
+ * FIELD dma_buf_attach_ops.move_notify -> .invalidate_mappings is NOT mapped
+ * here (move_notify is a common name); it is handled locally in xe_dma_buf.c.
+ */
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(7, 1, 0)
+#define dma_buf_move_notify dma_buf_invalidate_mappings
+#endif
+
 // We vendor our own copy of the DRM_GPUSVM module, so enable it here.
 
 #ifndef CONFIG_HMM_MIRROR 

--- a/include/drm/drm_colorop.h
+++ b/include/drm/drm_colorop.h
@@ -1,0 +1,35 @@
+#include_next <drm/drm_colorop.h>
+#ifndef __BACKPORT_DRM_COLOROP_H__
+#define __BACKPORT_DRM_COLOROP_H__
+
+#include <linux/version.h>
+
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(7, 1, 0)
+/*
+ * Linux 7.1: drm_plane_colorop_*_init() gained an extra parameter
+ * 'const struct drm_colorop_funcs *funcs' (right after 'plane'). The i915 code
+ * vendored from 7.0 still calls the old signature without funcs.
+ *
+ * struct drm_colorop_funcs only holds an optional destroy callback; the
+ * vendored intel_colorop.c defines no funcs, so NULL is the semantically
+ * correct value ("no driver-specific control funcs").
+ *
+ * These variadic macros inject NULL at position 4 so the vendored .c code stays
+ * UNCHANGED (maximum upstream proximity). The identically named macro does not
+ * expand recursively (C "blue paint" rule) -> real function call. The real
+ * declarations come via #include_next above, before these macros are defined,
+ * so there is no clash with the prototypes.
+ *
+ * Active only from 7.1; for 6.19..7.0 the old signature already matches.
+ */
+#define drm_plane_colorop_curve_1d_lut_init(dev, colorop, plane, ...) \
+	drm_plane_colorop_curve_1d_lut_init(dev, colorop, plane, NULL, __VA_ARGS__)
+
+#define drm_plane_colorop_ctm_3x4_init(dev, colorop, plane, ...) \
+	drm_plane_colorop_ctm_3x4_init(dev, colorop, plane, NULL, __VA_ARGS__)
+
+#define drm_plane_colorop_3dlut_init(dev, colorop, plane, ...) \
+	drm_plane_colorop_3dlut_init(dev, colorop, plane, NULL, __VA_ARGS__)
+#endif
+
+#endif /* __BACKPORT_DRM_COLOROP_H__ */

--- a/include/linux/dma-fence.h
+++ b/include/linux/dma-fence.h
@@ -29,4 +29,17 @@ dma_fence_test_signaled_flag(struct dma_fence *fence)
 	return test_bit(DMA_FENCE_FLAG_SIGNALED_BIT, &fence->flags);
 }
 #endif
+
+#if LINUX_VERSION_CODE < KERNEL_VERSION(7, 1, 0)
+/*
+ * Linux 7.1: struct dma_fence.lock (spinlock_t *) was replaced by a union
+ * extern_lock/inline_lock; access is now only via dma_fence_spinlock().
+ * Backport for older kernels so the vendored code can use the accessor
+ * uniformly (on 7.1+ the kernel header provides the real static inline).
+ */
+static inline spinlock_t *dma_fence_spinlock(struct dma_fence *fence)
+{
+	return fence->lock;
+}
+#endif
 #endif

--- a/include/linux/mm.h
+++ b/include/linux/mm.h
@@ -1,0 +1,26 @@
+#include_next <linux/mm.h>
+
+#ifndef __BACKPORT_LINUX_MM_H__
+#define __BACKPORT_LINUX_MM_H__
+
+#include <linux/version.h>
+
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(7, 1, 0)
+/*
+ * Linux 7.1: zap_vma_ptes() was removed and split into two helpers:
+ * zap_vma_range() (generic, NOT exported to modules) and
+ * zap_special_vma_range() (for VM_PFNMAP/special mappings, EXPORT_SYMBOL_GPL).
+ * The i915 tree vendored from 7.0 calls zap_vma_ptes() only on VM_PFNMAP VMAs
+ * (EXPECTED_FLAGS contains VM_PFNMAP, see i915_mm.c) and ignores the return
+ * value — so zap_special_vma_range() is the correct, linkable successor
+ * (zap_vma_range would compile but fail at MODPOST as undefined, because it is
+ * not exported).
+ */
+static inline void zap_vma_ptes(struct vm_area_struct *vma,
+				unsigned long address, unsigned long size)
+{
+	zap_special_vma_range(vma, address, size);
+}
+#endif
+
+#endif /* __BACKPORT_LINUX_MM_H__ */

--- a/include/linux/pagevec.h
+++ b/include/linux/pagevec.h
@@ -1,0 +1,18 @@
+#ifndef __BACKPORT_LINUX_PAGEVEC_H__
+#define __BACKPORT_LINUX_PAGEVEC_H__
+
+#include <linux/version.h>
+
+#if LINUX_VERSION_CODE < KERNEL_VERSION(7, 1, 0)
+/* Kernels < 7.1 still ship <linux/pagevec.h>. */
+#include_next <linux/pagevec.h>
+#endif
+
+/*
+ * Linux 7.1 removed <linux/pagevec.h> (the pagevec -> folio_batch
+ * conversion is complete). The vendored i915 tree still includes the
+ * header but no longer uses any pagevec symbols (verified: no
+ * `struct pagevec`/`pagevec_*` usage), so an empty shim suffices on 7.1+.
+ */
+
+#endif /* __BACKPORT_LINUX_PAGEVEC_H__ */


### PR DESCRIPTION
## Summary

Ports the vendored i915/xe tree to build and load against **Linux 7.1.x** (tested on 7.1.3). Addresses #429 and #456.

Guiding principle: stay as close to upstream as possible — prefer header shims (`include/`) and global renames (`include/config.h`) over touching vendored code, and migrate the vendored tree only where the struct/API change is semantic. Every change is gated with `LINUX_VERSION_CODE`, so pre-7.1 builds are unaffected.

## Changes (7.0 → 7.1 API deltas)

- **`dma_fence.lock`** is now a union (`extern_lock`/`inline_lock`); use the `dma_fence_spinlock()` accessor. Backport for <7.1 in `include/linux/dma-fence.h` plus type-checked migrations in `i915_active`, `intel_breadcrumbs`, `xe_sched_job`, `xe_hw_fence` and `compat/v7.0/dmabuf_dma_fence`.
- **`drm_plane_colorop_*_init()`** gained a mandatory `const struct drm_colorop_funcs *funcs` parameter; injected as `NULL` via a variadic-macro shim in `include/drm/drm_colorop.h` (vendored `.c` unchanged).
- **`INTEL_GMCH_CTRL`** renamed to `I830_GMCH_CTRL` (same value, `0x52`).
- **dynamic dma-buf**: `dma_buf_move_notify()` → `dma_buf_invalidate_mappings()`, and the `dma_buf_attach_ops.move_notify` callback field → `.invalidate_mappings`.
- **intel_vsec**: `intel_vsec_register()` and `pmt_callbacks.read_telem` now take `struct device *` instead of `struct pci_dev *`; bridged via a thin adapter so internal callers stay unchanged.
- **`zap_vma_ptes()`** was split; use the exported `zap_special_vma_range()` for the `VM_PFNMAP` mappings i915 tears down (`zap_vma_range` exists but is not exported to modules, so it fails at MODPOST).
- **`<linux/pagevec.h>`** was removed on 7.1; empty shim (no pagevec symbols used).
- **buddy allocator** moved to `<linux/gpu_buddy.h>` as `gpu_buddy_*`; global rename (`drm_buddy_print`/`drm_buddy_block_print` keep their names).

## Verification

**Build** — clean from scratch against 7.1.3: `i915.ko`, `xe.ko`, `kvmgt.ko`, `intel_sriov_compat.ko`, `vermagic 7.1.3`, MODPOST clean. Also builds reproducibly through a NixOS module derivation (same Makefile/`kernel.dev`).

**Runtime (live 7.1.3 host, Raptor Lake-S UHD 770 `8086:a780`)** — after `nixos-rebuild boot` + reboot:

- Loaded module is the patched one: `filename: …/updates/…/i915.ko`, `vermagic 7.1.3`, taint `(O)`; no i915 fatal in `dmesg`.
- iGPU `00:02.0`: `driver in use: i915`.
- **`sriov_numvfs = 7 / 7`** — the 7 VFs are created.
- VF `0000:00:02.1`: `driver in use: vfio-pci` — passthrough-ready.

**End-to-end** — the VF was passed through to a Windows 11 guest (libvirt `<hostdev>`), where the Intel UHD 770 initialises correctly (`STATUS=OK, PROBLEM=0`) with a matching Windows guest driver. So the full SR-IOV path — module → VFs → VFIO passthrough → guest — works on 7.1.3, not just the build.

_Note: the `.gitignore` additions are local dev-tooling ignores — happy to drop them if you'd prefer this PR to touch only the port code._

🤖 Generated with [Claude Code](https://claude.com/claude-code)
