### PR TITLE
PKGBUILD: reliably build HEAD of arbitrary branch

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -12,7 +12,9 @@ depends=('dkms')
 conflicts=("${pkgname}-git")
 backup=("etc/tmpfiles.d/i915-set-sriov-numvfs.conf")
 install=${pkgname}.install
-source=("$pkgname::git+file://$(pwd)/.git")
+_source_repo="$(cd "$(git rev-parse --git-common-dir)" && pwd -P)"
+_source_commit="$(git rev-parse HEAD)"
+source=("$pkgname::git+file://${_source_repo}#commit=${_source_commit}")
 sha256sums=('SKIP')
 
 package() {


### PR DESCRIPTION
Hi,
so I've been using i915-sriov-dkms for QEMU daily now, so awesome you're keeping this up!
Currently using it, thanks!


Anyways, trying to use makepkg on the v7.1 branch after the kernel upgrade to 7.1 just built from the master branch,

The below should reliably build the currently-checked-out committed HEAD of an arbitrary branch instead of falling back.