### PR TITLE
narrow down macro check, so latest branch keeps building against ongoing 6.18 point versions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -106,6 +106,7 @@ jobs:
       - name: Install Dependencies
         run: |
           pacman-key --init
+          sed -i '/^#\[\(core\|extra\)-testing\]/,/^$/s/^#//' /etc/pacman.conf
           pacman -Syu --noconfirm git linux-headers
       - name: Checkout
         uses: actions/checkout@v7
@@ -145,6 +146,7 @@ jobs:
       - name: Install Dependencies
         run: |
           pacman-key --init
+          sed -i '/^#\[\(core\|extra\)-testing\]/,/^$/s/^#//' /etc/pacman.conf
           pacman -Syu --noconfirm git linux-lts-headers
       - name: Checkout
         uses: actions/checkout@v7
@@ -184,6 +186,7 @@ jobs:
       - name: Install Dependencies
         run: |
           pacman-key --init
+          sed -i '/^#\[\(core\|extra\)-testing\]/,/^$/s/^#//' /etc/pacman.conf
           cat <<EOF >> /etc/pacman.conf
           [archlinuxcn]
           Server = https://repo.archlinuxcn.org/\$arch

--- a/Makefile
+++ b/Makefile
@@ -21,8 +21,9 @@ CONFTEST_H := $(CONFTEST_DIR)/results.h
 
 CONFTEST_COMPILE_TESTS := \
 	copy_from_user_inatomic_nontemporal \
-	pci_resize_resource_4args \
 	drm_exec_for_each_locked_object_no_index \
+	drm_fb_helper_alloc_info \
+	pci_resize_resource_4args \
 	xe_pmt_telem_read_kernel_device
 
 ifneq ($(filter 1 y,$(KBUILD_MODULES)),)

--- a/conftest.sh
+++ b/conftest.sh
@@ -87,6 +87,18 @@ ct_pci_resize_resource_4args() {
 	compile_check "$CODE" "IDB_PCI_RESIZE_RESOURCE_4ARGS" 1
 }
 
+ct_drm_fb_helper_alloc_info() {
+	CODE="
+	#include <drm/drm_fb_helper.h>
+	static void conftest_drm_fb_helper_alloc_info(void)
+	{
+		drm_fb_helper_alloc_info((struct drm_fb_helper *)NULL);
+	}
+	"
+
+	compile_check "$CODE" "IDB_HAVE_DRM_FB_HELPER_ALLOC_INFO" 1
+}
+
 ct_drm_exec_for_each_locked_object_no_index() {
 	CODE="
 	#include <drm/drm_exec.h>

--- a/drivers/gpu/drm/i915/display/intel_fbdev.c
+++ b/drivers/gpu/drm/i915/display/intel_fbdev.c
@@ -326,7 +326,7 @@ int intel_fbdev_driver_fbdev_probe(struct drm_fb_helper *helper,
 		goto out_unlock;
 	}
 
-#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 19, 0)
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 18, 44)
 	info = drm_fb_helper_alloc_info(helper);
 	if (IS_ERR(info)) {
 		drm_err(display->drm, "Failed to allocate fb_info (%pe)\n", info);

--- a/drivers/gpu/drm/i915/display/intel_fbdev.c
+++ b/drivers/gpu/drm/i915/display/intel_fbdev.c
@@ -267,7 +267,7 @@ int intel_fbdev_driver_fbdev_probe(struct drm_fb_helper *helper,
 	struct intel_display *display = to_intel_display(helper->dev);
 	struct intel_fbdev *ifbdev = to_intel_fbdev(helper);
 	struct intel_framebuffer *fb = ifbdev->fb;
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 19, 0)
+#ifndef IDB_HAVE_DRM_FB_HELPER_ALLOC_INFO
 	struct fb_info *info = helper->info;
 #else
 	struct fb_info *info;
@@ -326,7 +326,7 @@ int intel_fbdev_driver_fbdev_probe(struct drm_fb_helper *helper,
 		goto out_unlock;
 	}
 
-#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 18, 44)
+#ifdef IDB_HAVE_DRM_FB_HELPER_ALLOC_INFO
 	info = drm_fb_helper_alloc_info(helper);
 	if (IS_ERR(info)) {
 		drm_err(display->drm, "Failed to allocate fb_info (%pe)\n", info);


### PR DESCRIPTION
without adjustment, since 6.18.44 it results in:

```
drivers/gpu/drm/i915/display/intel_fbdev.c: In function ‘intel_fbdev_driver_fbdev_probe’:
drivers/gpu/drm/i915/display/intel_fbdev.c:330:16: error: implicit declaration of function ‘drm_fb_helper_alloc_info’; did you mean ‘drm_fb_helper_fill_info’? [-Wimplicit-function-declaration]
  330 |         info = drm_fb_helper_alloc_info(helper);
      |                ^~~~~~~~~~~~~~~~~~~~~~~~
      |                drm_fb_helper_fill_info
drivers/gpu/drm/i915/display/intel_fbdev.c:330:14: error: assignment to ‘struct fb_info *’ from ‘int’ makes pointer from integer without a cast [-Wint-conversion]
  330 |         info = drm_fb_helper_alloc_info(helper);
      |              ^
```